### PR TITLE
Add BaseNode + node wrappers, move orchestrator to router, tests & CI

### DIFF
--- a/.github/workflows/sync-develop-to-main.yml
+++ b/.github/workflows/sync-develop-to-main.yml
@@ -27,7 +27,7 @@ jobs:
           pr_body: |
             This PR is automatically created by CI to sync `develop` into `main`.
           pr_label: chore
-          GITHUB_TOKEN: ${{ secrets.PAT_PR }}
+          github_token: ${{ secrets.PAT_PR }}
 
       - name: Enable auto-merge on PR
         if: steps.create_pr.outputs.pull-request-number != ''

--- a/backend/app/main.py
+++ b/backend/app/main.py
@@ -1,18 +1,13 @@
-from fastapi import FastAPI, HTTPException
+from fastapi import FastAPI
 from fastapi.middleware.cors import CORSMiddleware
 from .config import get_allowed_origins
 from pydantic import BaseModel
 from typing import Optional, Dict, Any
 import uvicorn
 
-from agents.segmenter import segment_user
-from agents.retriever import retrieve_citations
-from agents.generator import generate_variants
-from agents.safety_gate import safety_check_and_filter
-from agents.analytics import evaluate_variants
-from services.delivery import send_email_mock
 from services.logger import get_logger
 from .routers.health import router as health_router
+from .routers.orchestrator import router as orchestrator_router
 
 logger = get_logger('orchestrator')
 app = FastAPI(title='EchoVoice-AI Orchestrator')
@@ -31,62 +26,7 @@ app.add_middleware(
 
 # Register routers (standard `routers/` package)
 app.include_router(health_router)
-
-
-class CustomerModel(BaseModel):
-    id: Optional[str]
-    name: Optional[str]
-    email: Optional[str]
-    last_event: Optional[str]
-    properties: Optional[Dict[str, Any]] = {}
-
-
-class OrchestrateRequest(BaseModel):
-    customer: CustomerModel
-
-
-@app.post('/orchestrate')
-async def orchestrate(payload: OrchestrateRequest):
-    customer = payload.customer.dict()
-    if not customer:
-        raise HTTPException(status_code=400, detail='customer missing')
-
-    # 1. Segmentation
-    segment = segment_user(customer)
-    logger.info(f"Segment: {segment}")
-
-    # 2. Retrieval
-    citations = retrieve_citations(customer)
-    logger.info(f"Citations: {citations}")
-
-    # 3. Generation
-    variants = generate_variants(customer, segment, citations)
-    logger.info(f"Generated {len(variants)} variants")
-
-    # 4. Safety checks
-    safety = safety_check_and_filter(variants)
-    logger.info(f"Safety safe={len(safety['safe'])} blocked={len(safety['blocked'])}")
-
-    # 5. Analytics / choose winner
-    analysis = evaluate_variants(safety['safe'], customer)
-    winner = analysis.get('winner')
-
-    # 6. Delivery (mock) — send winner if present
-    delivery_result = None
-    if winner:
-        variant = next((v for v in safety['safe'] if v.get('id') == winner['variant_id']), None)
-        if variant:
-            delivery_result = send_email_mock(customer.get('email'), variant.get('subject'), variant.get('body'))
-
-    response = {
-        'segment': segment,
-        'citations': citations,
-        'variants': variants,
-        'safety': safety,
-        'analysis': analysis,
-        'delivery': delivery_result
-    }
-    return response
+app.include_router(orchestrator_router)
 
 
 if __name__ == '__main__':

--- a/backend/app/nodes/analytics_node.py
+++ b/backend/app/nodes/analytics_node.py
@@ -1,0 +1,23 @@
+from typing import Any
+
+from .base_node import BaseNode
+from agents.analytics import evaluate_variants
+
+
+class AnalyticsNode(BaseNode):
+    """Node wrapper for analytics/evaluation.
+
+    Expects `data` to be a dict with keys `variants` and `customer`.
+    """
+
+    def __init__(self, name: str = "analytics"):
+        super().__init__(name)
+
+    def run(self, data: Any) -> Any:
+        if isinstance(data, dict):
+            variants = data.get("variants")
+            customer = data.get("customer")
+        else:
+            variants = data
+            customer = None
+        return evaluate_variants(variants, customer)

--- a/backend/app/nodes/generator_node.py
+++ b/backend/app/nodes/generator_node.py
@@ -1,0 +1,33 @@
+from typing import Any
+
+from .base_node import BaseNode
+from agents.generator import generate_variants
+
+
+class GeneratorNode(BaseNode):
+    """Node wrapper for the generation agent.
+
+    Expects `data` to be a dict with keys: `customer`, `segment`, `citations`.
+    """
+
+    def __init__(self, name: str = "generator"):
+        super().__init__(name)
+
+    def run(self, data: Any) -> Any:
+        customer = data.get("customer") if isinstance(data, dict) else data
+        segment = data.get("segment") if isinstance(data, dict) else None
+        citations = data.get("citations") if isinstance(data, dict) else None
+
+        # Accept either a string segment label or a segment dict
+        if isinstance(segment, str):
+            segment = {"segment": segment}
+
+        # Provide safe defaults so underlying agent code won't raise
+        if customer is None:
+            customer = {}
+        if segment is None:
+            segment = {}
+        if citations is None:
+            citations = []
+
+        return generate_variants(customer, segment, citations)

--- a/backend/app/nodes/retriever_node.py
+++ b/backend/app/nodes/retriever_node.py
@@ -1,0 +1,17 @@
+from typing import Any
+
+from .base_node import BaseNode
+from agents.retriever import retrieve_citations
+
+
+class RetrieverNode(BaseNode):
+    """Node wrapper for the retrieval agent.
+
+    Expects `data` to be a customer dict passed to `retrieve_citations`.
+    """
+
+    def __init__(self, name: str = "retriever"):
+        super().__init__(name)
+
+    def run(self, data: Any) -> Any:
+        return retrieve_citations(data)

--- a/backend/app/nodes/safety_node.py
+++ b/backend/app/nodes/safety_node.py
@@ -1,0 +1,18 @@
+from typing import Any
+
+from .base_node import BaseNode
+from agents.safety_gate import safety_check_and_filter
+
+
+class SafetyNode(BaseNode):
+    """Node wrapper for the safety gate.
+
+    Expects `data` to be a list of variants (or dict with 'variants' key).
+    """
+
+    def __init__(self, name: str = "safety"):
+        super().__init__(name)
+
+    def run(self, data: Any) -> Any:
+        variants = data if not isinstance(data, dict) else data.get("variants")
+        return safety_check_and_filter(variants)

--- a/backend/app/nodes/segmenter_node.py
+++ b/backend/app/nodes/segmenter_node.py
@@ -1,0 +1,29 @@
+from typing import Any
+
+from .base_node import BaseNode
+from agents.segmenter import segment_user
+
+
+class SegmenterNode(BaseNode):
+    """Node wrapper around the `segment_user` utility.
+
+    This allows the segmenter to be used as a pluggable node in the
+    orchestrator graph while sharing a consistent interface (`run`).
+    """
+
+    def __init__(self, name: str = "segmenter"):
+        super().__init__(name)
+
+    def run(self, data: Any) -> dict:
+        """Run segmentation on `data` (expected dict-like customer).
+
+        Returns the segment dict produced by `agents.segmenter.segment_user`.
+        """
+        return segment_user(data)
+
+
+if __name__ == "__main__":
+    # Quick manual smoke test
+    sample = {"viewed_page": "pricing", "form_started": "yes"}
+    node = SegmenterNode()
+    print(node.run(sample))

--- a/backend/app/routers/orchestrator.py
+++ b/backend/app/routers/orchestrator.py
@@ -1,0 +1,80 @@
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+from typing import Optional, Dict, Any
+
+from ..nodes.segmenter_node import SegmenterNode
+from ..nodes.retriever_node import RetrieverNode
+from ..nodes.generator_node import GeneratorNode
+from ..nodes.safety_node import SafetyNode
+from ..nodes.analytics_node import AnalyticsNode
+from services.delivery import send_email_mock
+from services.logger import get_logger
+
+router = APIRouter()
+logger = get_logger("orchestrator")
+
+
+class CustomerModel(BaseModel):
+    id: Optional[str]
+    name: Optional[str]
+    email: Optional[str]
+    last_event: Optional[str]
+    properties: Optional[Dict[str, Any]] = {}
+
+
+class OrchestrateRequest(BaseModel):
+    customer: CustomerModel
+
+
+# Instantiate nodes (simple singletons for this router)
+segmenter = SegmenterNode()
+retriever = RetrieverNode()
+generator = GeneratorNode()
+safety = SafetyNode()
+analytics = AnalyticsNode()
+
+
+@router.post("/orchestrate")
+async def orchestrate(payload: OrchestrateRequest):
+    customer = payload.customer.dict()
+    if not customer:
+        raise HTTPException(status_code=400, detail="customer missing")
+
+    # 1. Segmentation
+    segment = segmenter.run(customer)
+    logger.info(f"Segment: {segment}")
+
+    # 2. Retrieval
+    citations = retriever.run(customer)
+    logger.info(f"Citations: {citations}")
+
+    # 3. Generation
+    variants = generator.run({"customer": customer, "segment": segment, "citations": citations})
+    logger.info(f"Generated {len(variants) if variants else 0} variants")
+
+    # 4. Safety checks
+    safety_result = safety.run(variants)
+    safe_count = len(safety_result.get("safe", [])) if isinstance(safety_result, dict) else 0
+    blocked_count = len(safety_result.get("blocked", [])) if isinstance(safety_result, dict) else 0
+    logger.info(f"Safety safe={safe_count} blocked={blocked_count}")
+
+    # 5. Analytics / choose winner
+    analysis = analytics.run({"variants": safety_result.get("safe", []), "customer": customer}) if isinstance(safety_result, dict) else None
+    winner = analysis.get("winner") if isinstance(analysis, dict) else None
+
+    # 6. Delivery (mock)
+    delivery_result = None
+    if winner and isinstance(safety_result, dict):
+        variant = next((v for v in safety_result.get("safe", []) if v.get("id") == winner.get("variant_id")), None)
+        if variant:
+            delivery_result = send_email_mock(customer.get("email"), variant.get("subject"), variant.get("body"))
+
+    response = {
+        "segment": segment,
+        "citations": citations,
+        "variants": variants,
+        "safety": safety_result,
+        "analysis": analysis,
+        "delivery": delivery_result,
+    }
+    return response

--- a/backend/tests/test_analytics_node.py
+++ b/backend/tests/test_analytics_node.py
@@ -1,0 +1,9 @@
+from app.nodes.analytics_node import AnalyticsNode
+
+
+def test_analytics_node_evaluates():
+    node = AnalyticsNode()
+    variants = [{"id": "v1", "score": 0.5}]
+    customer = {"user_id": "U1"}
+    res = node.run({"variants": variants, "customer": customer})
+    assert isinstance(res, dict) or res is None

--- a/backend/tests/test_generator_node.py
+++ b/backend/tests/test_generator_node.py
@@ -1,0 +1,12 @@
+from app.nodes.generator_node import GeneratorNode
+
+
+def test_generator_node_returns_list():
+    node = GeneratorNode()
+    payload = {
+        "customer": {"user_id": "U1"},
+        "segment": "unknown",
+        "citations": [],
+    }
+    res = node.run(payload)
+    assert isinstance(res, list) or res is None

--- a/backend/tests/test_retriever_node.py
+++ b/backend/tests/test_retriever_node.py
@@ -1,0 +1,9 @@
+from app.nodes.retriever_node import RetrieverNode
+
+
+def test_retriever_node_returns_list_or_iterable():
+    node = RetrieverNode()
+    # minimal customer
+    customer = {"user_id": "U1"}
+    res = node.run(customer)
+    assert hasattr(res, "__iter__") or res is None

--- a/backend/tests/test_safety_node.py
+++ b/backend/tests/test_safety_node.py
@@ -1,0 +1,9 @@
+from app.nodes.safety_node import SafetyNode
+
+
+def test_safety_node_filters_structure():
+    node = SafetyNode()
+    # safety expects variants list; use simple list
+    variants = [{"id": "v1", "subject": "hi", "body": "text"}]
+    res = node.run(variants)
+    assert isinstance(res, dict) or res is None

--- a/backend/tests/test_segmenter_node.py
+++ b/backend/tests/test_segmenter_node.py
@@ -1,0 +1,10 @@
+from app.nodes.segmenter_node import SegmenterNode
+
+
+def test_segmenter_node_run_shape():
+    node = SegmenterNode()
+    customer = {"viewed_page": "pricing", "form_started": "yes"}
+    result = node.run(customer)
+    assert isinstance(result, dict)
+    assert "segment" in result
+    assert "funnel_stage" in result


### PR DESCRIPTION
## **Summary**

This PR introduces a consistent node architecture, moves orchestration logic into a dedicated router, adds unit tests across nodes, fixes import/test discovery issues, and improves overall robustness.

---

## **What Changed (Key Files)**

### **Nodes / Core**

* **`base_node.py`** — Defines the new abstract `BaseNode` with a required `run()` method.
* **`segmenter_node.py`** — New example node implementation.
* **`retriever_node.py`** — Node wrapper for retrieval agent.
* **`generator_node.py`** — Node wrapper (now robust to string/dict segment input).
* **`safety_node.py`** — Node wrapper for safety agent.
* **`analytics_node.py`** — Node wrapper for analytics agent.

---

### **Orchestrator / Routes**

* **`orchestrator.py`** — New router exposing `POST /orchestrate`, composing the node pipeline.
* **`main.py`** — Registers the orchestrator router and removes inline orchestration logic.

---

### **Health + Docs**

* **`health.py`** — Provides `GET /health` (and optional root redirect/alias).

---

### **Tests & Test Infrastructure**

* **Node tests:**
  `test_segmenter_node.py`,
  `test_retriever_node.py`,
  `test_generator_node.py`,
  `test_safety_node.py`,
  `test_analytics_node.py`
  → Adds basic shape/behavior tests for nodes.

* **`test_health.py`** — Validates the `/health` endpoint.

* **`pytest.ini`** — Ensures `backend/` is added to `PYTHONPATH` for proper test discovery.

* **`conftest.py`** — Adds fallback `sys.path` insertion for local runs and editors that don’t set PYTHONPATH.

---

### **CI**

* **`ci-python.yml`** — GitHub Actions workflow that runs tests on push/PR to `main`.

---

### **Misc Fixes**

* Absolute imports added in `orchestrator.py` so both server and pytest paths work.
* `GeneratorNode` hardened to accept either a `str` or `dict` segment, preventing `AttributeError` when agents return slightly different shapes.

---

## **Why**

* Establishes a consistent, pluggable node interface via `BaseNode`.
* Moves orchestration logic out of `main.py` for cleaner architecture and testability.
* Adds proper unit tests + CI to prevent regressions.
* Fixes import and path issues to ensure pytest works both locally and in GitHub Actions.

---

## **How to Test Locally**

### **Install dependencies**

```bash
pip install -r requirements.txt
```

### **Run all unit tests**

```bash
pytest
```

### **Start the server and smoke-check**

```bash
uvicorn app.main:app --reload
```

### **Smoke test: health**

```bash
curl http://localhost:8000/health
```

### **Smoke test: orchestrator**

```bash
curl -X POST http://localhost:8000/orchestrate -H "Content-Type: application/json" -d '{"input": "hello"}'
```

---

## **Acceptance Criteria**

* `GET /health` returns `200` and `{"status":"ok"}`.
* `pytest` passes with no unexpected failures.
* `POST /orchestrate` runs the node sequence without errors.
* CI workflow executes and succeeds on PRs to `main`.

---

## **Notes / Follow-Ups**

* Nodes are currently singletons; can be converted to FastAPI dependencies for per-request configuration.
* Node tests are lightweight shape tests. If needed, we can implement strict contract tests with mocks.
* `GeneratorNode` accepts string/dict segment inputs for compatibility; can be tightened if desired.
* A richer readiness check (`/health/readiness`) can be added for DB, vector store, or external services.

---
